### PR TITLE
Update 1.19.4 and below 'convert_recipes.py'

### DIFF
--- a/1.19.4 and below/data/minecraft/advancements/convert_recipes.py
+++ b/1.19.4 and below/data/minecraft/advancements/convert_recipes.py
@@ -14,17 +14,12 @@ for root, dirs, files in os.walk("./recipes"):
                     "parent": "minecraft:recipes/root",
                     "criteria": {
                         "was_crafted": {
+                          "trigger": "minecraft:recipe_unlocked",
                           "conditions": {
-                            "items": [
-                              {
-                                "items": [
-                                  "minecraft:{}".format(file[:len(file)-5])
-                                ]
-                              }
-                            ]
+                            "recipe": "minecraft:{}".format(file[:len(file)-5])
                           }
-                          }
-                        },
+                        }
+                    },
                     "requirements": [
                         [
                         "was_crafted"


### PR DESCRIPTION
We need a trigger to have the advancements work properly (I tried your datapack with this script on 1.19.1 and on 1.16.5 but it does'nt work at all...).

We keep the idea to reveal a recipe only if the player crafts said recipe. But below 1.20-ish, the 'recipe_crafted' trigger does not exist. We have a way around with the existing 'recipe_unlocked' trigger, which is usually used for 'doLimitedCrafting' servers. This trigger normally triggers if a player is given a special recipe book. But it also triggers if the player crafts for the first time a recipe (thus, this will datapack will never work for 'doLimitedCrafting' server, but those servers might not need this datapack).